### PR TITLE
Use AWS CLI from brew

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,6 +7,7 @@ all_packages:
   brew:
   - autoconf
   - bash-completion
+  - awscli
   - curl
   - gh
   - git
@@ -50,9 +51,6 @@ all_packages:
   pip:
   - ansible
   - ansible-lint
-  - aws-sam-cli
-  - awscli
-  - azure-cli
   - ipython
   - virtualenvwrapper
   - yamllint


### PR DESCRIPTION
# Description

AWS CLI v2 is not available through PyPI